### PR TITLE
Implement v2 signature based API keys

### DIFF
--- a/caddyfile.go
+++ b/caddyfile.go
@@ -15,13 +15,15 @@ func init() {
 
 // UnmarshalCaddyfile sets up caddy-token from Caddyfile tokens. Syntax:
 //
-//			token {
-//			  file <token_file>
-//			  issuer <issuer_url>
-//		      injectOrgHeader true
-//			  allowUpstreamAuth true
-//	          tenantOrgClaim ort
-//			}
+//	token {
+//	  file <token_file>
+//	  issuer <issuer_url>
+//	  injectOrgHeader true
+//	  allowUpstreamAuth true
+//	  tenantOrgClaim ort
+//	  signingKey <key>
+//  }
+
 func (m *Middleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	m.InjectOrgHeader = true // default
 	for d.Next() {
@@ -67,6 +69,11 @@ func (m *Middleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.ArgErr()
 				}
 				m.TenantOrgClaim = d.Val()
+			case "signingKey":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				m.SigningKey = d.Val()
 			default:
 				return d.Errf("unrecognized subdirective '%s'", d.Val())
 			}

--- a/cmd/tokengen/verify.go
+++ b/cmd/tokengen/verify.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"github.com/loafoe/caddy-token/keys"
+	"github.com/spf13/cobra"
+)
+
+// generateCmd represents the generate command
+var verifyCmd = &cobra.Command{
+	Use:     "verify",
+	Aliases: []string{"v"},
+	Short:   "Verify a token.",
+	Long:    `Verify a a token. This command will verify a token based on the parameters provided.`,
+	Run:     tokenVerify,
+}
+
+func tokenVerify(cmd *cobra.Command, args []string) {
+	key, _ := cmd.Flags().GetString("key")
+	token, _ := cmd.Flags().GetString("token")
+	if key == "" || token == "" {
+		fmt.Println("Please provide all required parameters")
+		return
+	}
+	ok, apiKey, err := keys.VerifyAPIKey(token, key)
+	if !ok {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(apiKey)
+}
+
+func init() {
+	rootCmd.AddCommand(verifyCmd)
+	verifyCmd.Flags().StringP("key", "k", "", "Key to use for token verification")
+	verifyCmd.Flags().StringP("token", "t", "", "Token to verify")
+}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgraph-io/badger v1.6.2 // indirect
 	github.com/dgraph-io/badger/v2 v2.2007.4 // indirect
 	github.com/dgraph-io/ristretto v0.1.0 // indirect
@@ -84,6 +85,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.13.2 // indirect
 	github.com/pires/go-proxyproto v0.7.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
@@ -106,6 +108,7 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/tailscale/tscert v0.0.0-20240517230440-bbccfbf48933 // indirect
 	github.com/urfave/cli v1.22.14 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/keys/generate.go
+++ b/keys/generate.go
@@ -1,0 +1,111 @@
+package keys
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+)
+
+const Prefix = "lst_"
+
+// GenerateSignature signs the API key with the given password using HMAC-SHA256
+func GenerateSignature(payload, password string) string {
+	h := hmac.New(sha256.New, []byte(password))
+	h.Write([]byte(payload))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// VerifySignature verifies the provided API key with the stored signature
+func VerifySignature(payload, providedSignature, password string) bool {
+	expectedSignature := GenerateSignature(payload, password)
+	return hmac.Equal([]byte(expectedSignature), []byte(providedSignature))
+}
+
+func VerifyAPIKey(apiKey, password string) (bool, *Key, error) {
+	var key Key
+	prefixRemoved := strings.TrimPrefix(apiKey, Prefix)
+	split := strings.Split(prefixRemoved, ".")
+	if len(split) != 2 {
+		return false, nil, fmt.Errorf("invalid token format")
+	}
+	payload := split[0]
+	signature := split[1]
+	if !VerifySignature(payload, signature, password) {
+		return false, nil, fmt.Errorf("signature mismatch")
+	}
+	decodedString, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return false, nil, fmt.Errorf("decode token: %w", err)
+	}
+
+	err = json.Unmarshal([]byte(decodedString), &key)
+	if err != nil {
+		return false, nil, fmt.Errorf("unmarshal token: %w '%s'", err, decodedString)
+	}
+	return true, &key, nil
+}
+
+func GenerateAPIKey(version, password, org, env, region, project string, scopes []string) (string, error) {
+	randomCount := 12
+	bail := 4
+	var newToken Key
+	newToken.Organization = org
+	newToken.Environment = env
+	newToken.Region = region
+	newToken.Project = project
+	newToken.Scopes = scopes
+	newToken.Expires = time.Now().Unix() + (60 * 60 * 24 * 365) // 1 year
+	for {
+		if bail <= 0 {
+			return "", fmt.Errorf("failed to generate a valid token")
+		}
+		newToken.Token = generateRandomString(randomCount)
+		switch version {
+		case "1":
+			newToken.Version = "1"
+			marshalled, _ := json.Marshal(newToken)
+			key := base64.StdEncoding.EncodeToString(marshalled)
+			if strings.HasSuffix(key, "=") {
+				randomCount = randomCount + 1
+				bail = bail - 1
+				continue
+			}
+			// We have a good-looking newToken, return it
+			return fmt.Sprintf("%s%s", Prefix, key), nil
+		case "2":
+			newToken.Version = "2"
+			if password == "" {
+				return "", fmt.Errorf("pease provide a password for token version 2")
+			}
+			marshalled, _ := json.Marshal(newToken)
+			payload := base64.StdEncoding.EncodeToString(marshalled)
+			if strings.HasSuffix(payload, "=") {
+				randomCount = randomCount + 1
+				bail = bail - 1
+				continue
+			}
+			signature := GenerateSignature(payload, password)
+			return fmt.Sprintf("%s%s.%s", Prefix, payload, signature), nil
+		default:
+			return "", fmt.Errorf("invalid token version: %s", version)
+		}
+	}
+}
+
+// generateRandomString generates a random alphanumeric string of length n.
+func generateRandomString(n int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, n)
+	for i := range b {
+		num, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		b[i] = charset[num.Int64()]
+	}
+	return string(b)
+}

--- a/keys/generate_test.go
+++ b/keys/generate_test.go
@@ -1,0 +1,27 @@
+package keys_test
+
+import (
+	"github.com/loafoe/caddy-token/keys"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGenerateAPIKey(t *testing.T) {
+	password := "P0oCPjKTPWsua243"
+	generated, err := keys.GenerateAPIKey("2", password, "org", "env", "region", "project", []string{"scope"})
+	if !assert.Nil(t, err) {
+		return
+	}
+	ok, key, err := keys.VerifyAPIKey(generated, password)
+	if !assert.Nil(t, err) {
+		return
+	}
+	if !assert.True(t, ok) {
+		return
+	}
+	assert.Equal(t, "org", key.Organization)
+	assert.Equal(t, "env", key.Environment)
+	assert.Equal(t, "region", key.Region)
+	assert.Equal(t, "project", key.Project)
+	assert.Equal(t, []string{"scope"}, key.Scopes)
+}

--- a/keys/key.go
+++ b/keys/key.go
@@ -1,0 +1,12 @@
+package keys
+
+type Key struct {
+	Version      string   `json:"v"`
+	Token        string   `json:"t"`
+	Organization string   `json:"o"`
+	Environment  string   `json:"e,omitempty"`
+	Region       string   `json:"r"`
+	Project      string   `json:"p,omitempty"`
+	Scopes       []string `json:"s,omitempty"`
+	Expires      int64    `json:"x,omitempty"`
+}


### PR DESCRIPTION
v2 API keys are based on HMAC256 signature validation. This means we only need to store the signing key. Received API keys can be verified and don't need to be stored server side.